### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ Please report bugs as [issues](https://github.com/MattSurabian/DuckHunt-JS/issue
 
 ## Contributing
 Pull requests are welcome! Please ensure code style and quality compliance with `npm run lint` and include any built files.
+
+[![Run on Repl.it](https://repl.it/badge/github/MattSurabian/DuckHunt-JS)](https://repl.it/github/MattSurabian/DuckHunt-JS)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).